### PR TITLE
mastery pass + spell info fancy reformat

### DIFF
--- a/src/Parser/Monk/Mistweaver/Modules/Features/StatValues.js
+++ b/src/Parser/Monk/Mistweaver/Modules/Features/StatValues.js
@@ -17,9 +17,17 @@ class StatValues extends BaseHealerStatValues {
       return 0;
     }
 
-    //mastery % delta has to be applied over the base heal at 100% mastery
-    const baseHeal = healVal.effective / this.statTracker.currentMasteryPercentage;
-    return baseHeal / this.statTracker.masteryRatingPerPercent;
+    // assuming gust heal vs. mastery % are linear and start at 0 ( gust_heal = K * mast_pct )
+    // h2 / h1 = (K * rat + 1.04) / (K * (rat-1) + 1.04 )
+    // solving that for h2 - h1 brings...
+    const h2 = healVal.effective;
+    const k = 1 / this.statTracker.masteryRatingPerPercent;
+    const r = this.statTracker.currentMasteryRating;
+    return h2 * ( 1 - ( ( k*(r-1)+1.04 ) / ( k*r+1.04 ) ) );
+
+    //approach 2: apply mastery % delta over the base heal at 100% mastery
+    //const baseHeal = healVal.effective / this.statTracker.currentMasteryPercentage;
+    //return baseHeal / this.statTracker.masteryRatingPerPercent;
   }
 
   

--- a/src/Parser/Monk/Mistweaver/Modules/Features/StatValues.js
+++ b/src/Parser/Monk/Mistweaver/Modules/Features/StatValues.js
@@ -18,12 +18,12 @@ class StatValues extends BaseHealerStatValues {
     }
 
     // assuming gust heal vs. mastery % are linear and start at 0 ( gust_heal = K * mast_pct )
-    // h2 / h1 = (K * rat + 1.04) / (K * (rat-1) + 1.04 )
+    // h2 / h1 = mast_pct(rat) / mast_pct(rat-1)
     // solving that for h2 - h1 brings...
-    const h2 = healVal.effective;
-    const k = 1 / this.statTracker.masteryRatingPerPercent;
     const r = this.statTracker.currentMasteryRating;
-    return h2 * ( 1 - ( ( k*(r-1)+1.04 ) / ( k*r+1.04 ) ) );
+    return healVal.effective * ( 1 - ( 
+      this.statTracker.masteryPercentage(r-1, true) / this.statTracker.masteryPercentage(r, true) 
+    ) );
 
     //approach 2: apply mastery % delta over the base heal at 100% mastery
     //const baseHeal = healVal.effective / this.statTracker.currentMasteryPercentage;

--- a/src/Parser/Monk/Mistweaver/Modules/Features/StatValues.js
+++ b/src/Parser/Monk/Mistweaver/Modules/Features/StatValues.js
@@ -1,11 +1,5 @@
-
-
 import BaseHealerStatValues from 'Parser/Core/Modules/Features/BaseHealerStatValues';
 import STAT from 'Parser/Core/Modules/Features/STAT';
-import Combatants from 'Parser/Core/Modules/Combatants';
-
-import CritEffectBonus from 'Parser/Core/Modules/Helpers/CritEffectBonus';
-import StatTracker from 'Parser/Core/Modules/StatTracker';
 
 import SPELL_INFO from './StatValuesSpellInfo';
 
@@ -14,24 +8,18 @@ import SPELL_INFO from './StatValuesSpellInfo';
  *
  */
 class StatValues extends BaseHealerStatValues {
-  static dependencies = {
-    combatants: Combatants,
-    critEffectBonus: CritEffectBonus,
-    statTracker: StatTracker,
-  };
 
   spellInfo = SPELL_INFO;
 
   _mastery(event, healVal) {
     if (healVal.overheal) {
-      // If a spell overheals, it could not have healed for more. Seeing as Mastery only adds HP on top of the existing heal we can skip it as increasing the power of this heal would only be more overhealing.
+      // If a spell overheals, it could not have healed for more.
       return 0;
     }
 
-    const currMastery = this.statTracker.currentMasteryRating;
-    const healIncreaseFromOneMastery = 1 / currMastery;
-    return healVal.effective * healIncreaseFromOneMastery;
-
+    //mastery % delta has to be applied over the base heal at 100% mastery
+    const baseHeal = healVal.effective / this.statTracker.currentMasteryPercentage;
+    return baseHeal / this.statTracker.masteryRatingPerPercent;
   }
 
   

--- a/src/Parser/Monk/Mistweaver/Modules/Features/StatValuesSpellInfo.js
+++ b/src/Parser/Monk/Mistweaver/Modules/Features/StatValuesSpellInfo.js
@@ -1,4 +1,4 @@
-import SPELLS from 'common/SPELLS';
+import S from 'common/SPELLS/MONK';
 
 /*
  * Fields:
@@ -15,155 +15,42 @@ import SPELLS from 'common/SPELLS';
 
 // This only works with actual healing events; casts are not recognized.
 
+// "default" behavior (not spammable, not a HOT)
+const def = (changed = {}) => {
+  return {
+      int: true,
+      crit: true,
+      vers: true,
+      mastery: false,        // only gust of mists entries scale with mastery
+      hasteHpm: false,       // true if it is a HOT
+      hasteHpct: false,      // true if it is spammable (HPCT currently not calculated though)
+      ...changed,
+  };
+};
+
 export default {
-  [SPELLS.ENVELOPING_MISTS.id]: {
-    int: true,
-    crit: true,
-    hasteHpm: true,
-    hasteHpct: true,
-    mastery: false, //Procs Gusts
-    vers: true,
-  },
-  [SPELLS.ESSENCE_FONT.id]: {
-    int: true,
-    crit: true,
-    hasteHpct: false,
-    mastery: false, 
-    vers: true,
-  },
-  [SPELLS.ESSENCE_FONT_BUFF.id]: {
-    int: true,
-    crit: true,
-    hasteHpm: true,
-    mastery: false, 
-    vers: true,
-  },
-  [SPELLS.RENEWING_MIST_HEAL.id]: {
-    int: true,
-    crit: true,
-    hasteHpm: true,
-    hasteHpct: false,
-    mastery: false, // Procs Gusts
-    vers: true,
-  },
-  [SPELLS.SHEILUNS_GIFT.id]: {
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false, // Procs Gusts
-    vers: true,
-  },
-  [SPELLS.VIVIFY.id]: {
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: true,
-    mastery: false, // Procs Gusts
-    vers: true,
-  },
-  [SPELLS.CHI_BURST_HEAL.id]: {
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false,
-    vers: true,
-  },
-  [SPELLS.GUSTS_OF_MISTS.id]: {
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: true, // Procs Gusts
-    vers: false,
-  },
-  [SPELLS.WHISPERS_OF_SHAOHAO.id]: {
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false,
-    vers: true,
-  },
-  [SPELLS.CELESTIAL_BREATH.id]: { 
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false, 
-    vers: true,
-  },
-  [SPELLS.SOOTHING_MIST.id]: { 
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: true,
-    mastery: false, 
-    vers: true,
-  },
-  [SPELLS.REFRESHING_JADE_WIND_HEAL.id]: { 
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: true,
-    mastery: false, 
-    vers: true,
-  },
-  [SPELLS.MISTS_OF_SHEILUN.id]: { 
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false, 
-    vers: true,
-  },
-  [SPELLS.REVIVAL.id]: { 
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false,
-    vers: true,
-  },
-  [SPELLS.BLESSINGS_OF_YULON.id]: { 
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false, 
-    vers: true,
-  },
-  [SPELLS.LIFE_COCOON.id]: { 
-    int: true,
-    crit: false,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false, 
-    vers: true,
-  },
-  [SPELLS.CRANE_HEAL.id]: { 
-    int: true,
-    crit: false,
-    hasteHpm: false,
-    hasteHpct: true,
-    mastery: false, 
-    vers: true,
-  },
-  [SPELLS.TRANQUIL_MIST.id]: { // T21 2P HoT
-    int: true,
-    crit: true,
-    hasteHpm: true,
-    hasteHpct: false,
-    mastery: false, 
-    vers: true,
-  },
-  [SPELLS.CHI_BOLT.id]: { // T21 2P HoT
-    int: true,
-    crit: true,
-    hasteHpm: false,
-    hasteHpct: false,
-    mastery: false, 
-    vers: true,
-  },
+  [S.EFFUSE.id] : def({ hasteHpct : true }),
+  [S.ENVELOPING_MISTS.id] : def({ hasteHpm : true, hasteHpct : true }),
+  [S.ESSENCE_FONT.id] : def(),
+  [S.ESSENCE_FONT_BUFF.id] : def({ hasteHpm : true }),
+  [S.LIFE_COCOON.id] : def(),
+  [S.RENEWING_MIST_HEAL.id] : def({ hasteHpm : true }),
+  [S.REVIVAL.id] : def(),
+  [S.SHEILUNS_GIFT.id] : def(),
+  //note: uplifting trance would scale with haste. meh...
+  [S.VIVIFY.id] : def({ hasteHpct : true }),
+  //hpm or hpct? (wouldnt matter much since its free and weak)
+  [S.SOOTHING_MIST.id] : def({ hasteHpct : true }),
+  [S.CHI_BURST_HEAL.id] : def(),
+  [S.REFRESHING_JADE_WIND_HEAL.id] : def({ hasteHpct : true }),
+  //hpm or hpct?
+  [S.CRANE_HEAL.id] : def({ hasteHpct : true }),
+  [S.GUSTS_OF_MISTS.id] : def({ mastery : true }),
+  [S.WHISPERS_OF_SHAOHAO.id] : def(),
+  [S.MISTS_OF_SHEILUN.id] : def(),
+  [S.CELESTIAL_BREATH.id] : def(),
+  [S.BLESSINGS_OF_YULON.id] : def(),
+  [S.SHELTER_OF_RIN_HEAL.id] : def(), //chest legendary
+  [S.TRANQUIL_MIST.id] : def({ hasteHpm : true }), //t21 2p
+  [S.CHI_BOLT.id] : def(),  //t21 4p
 };


### PR DESCRIPTION
 - apply the mastery % per rating over what gusts would heal at 100% mastery
 - I took the freedom to reformat the spell list with the one I had here, contents are the same (youre the boss, if you dont like it you can revert it)

I compared 2 logs and mastery is still yielding way higher values than sheet, but at least its not 2x the value as before.

https://www.warcraftlogs.com/reports/PCWyNAnZQ2mG81az/#fight=50&source=40&type=healing
h aggramar: 0.77 on sheet, 0.97 on analyzer
https://www.warcraftlogs.com/reports/zRrctNqLwCyFXMh7/#fight=21&type=healing&source=202
m portal: 0.63 on sheet, 0.87 on analyzer

Possible points:
 - how valid is HPCT? If it is something not much meaningful it could just be removed (like in the rdruid box)
 - wouldnt chi-ji scale with HPM, since it would be more healing for the same cast? 